### PR TITLE
Add env variables

### DIFF
--- a/bin/qmri-neuropipe.py
+++ b/bin/qmri-neuropipe.py
@@ -46,9 +46,9 @@ if args.proc_json:
         t_dict.update(json.load(f))
         args, unknown = parser.parse_known_args(namespace=t_args)
 
-
-os.environ['CUDA_VISIBLE_DEVICES'] = '2'
-os.environ['TF_FORCE_GPU_ALLOW_GROWTH'] = 'true'
+if args.gpu == True:
+    os.environ['CUDA_VISIBLE_DEVICES'] = args.cuda_device
+    os.environ['TF_FORCE_GPU_ALLOW_GROWTH'] = 'true'
 
 ##################################
 ##################################

--- a/bin/qmri-neuropipe.py
+++ b/bin/qmri-neuropipe.py
@@ -47,6 +47,9 @@ if args.proc_json:
         args, unknown = parser.parse_known_args(namespace=t_args)
 
 
+os.environ['CUDA_VISIBLE_DEVICES'] = '2'
+os.environ['TF_FORCE_GPU_ALLOW_GROWTH'] = 'true'
+
 ##################################
 ##################################
 ##### PROCESSING STARTS HERE #####


### PR DESCRIPTION
Add environment variables to limit the number of CUDA devices that Synb0 can use and CUDA memory tensorflow can occupy.